### PR TITLE
Fix for off('*', '*') throwing an exception

### DIFF
--- a/event-pubsub.js
+++ b/event-pubsub.js
@@ -20,7 +20,6 @@ function unsub(type,handler){
     checkScope.apply(this);
 
     if(type=='*'){
-        var params=Array.prototype.slice.call(arguments,1);
         for(
             var keys    = Object.keys(this._events_),
                 count   = keys.length,
@@ -28,9 +27,9 @@ function unsub(type,handler){
             i<count;
             i++
         ){
-            var args=params.unshift(keys[i]);
-            this.off.call(args);
+            unsub.call(this, keys[i], handler);
         }
+        return;
     }
 
     if(!this._events_[type])


### PR DESCRIPTION
`unsub` was incorrectly treating the return value of `Array.unshift` as an array, when in fact it is the length of the array. It was also calling `this.off.call` incorrectly.