### PR TITLE
Fix for off('*', '*') throwing an exception too

### DIFF
--- a/event-pubsub-browser.js
+++ b/event-pubsub-browser.js
@@ -23,7 +23,7 @@ window.pubsub=(
             checkScope.apply(this);
 
             if(type=='*'){
-                var params=Array.prototype.slice.call(arguments,1);
+                delete this._events_['*'];
                 for(
                     var keys    = Object.keys(this._events_),
                         count   = keys.length,
@@ -31,8 +31,7 @@ window.pubsub=(
                     i<count;
                     i++
                 ){
-                    var args=params.unshift(keys[i]);
-                    this.off.call(args);
+                    unsub.call(this, keys[i], handler);
                 }
             }
 

--- a/event-pubsub.js
+++ b/event-pubsub.js
@@ -13,14 +13,14 @@ function sub(type,handler){
 }
 
 function unsub(type,handler){
-    if(!handler){
+    if(!handler && type !== '*'){
         var err=new ReferenceError('handler not defined. if you wish to remove all handlers from the event please pass "*" as the handler');
         throw err;
     }
     checkScope.apply(this);
 
     if(type=='*'){
-        var params=Array.prototype.slice.call(arguments,1);
+        delete this._events_['*'];
         for(
             var keys    = Object.keys(this._events_),
                 count   = keys.length,
@@ -28,8 +28,7 @@ function unsub(type,handler){
             i<count;
             i++
         ){
-            var args=params.unshift(keys[i]);
-            this.off.call(args);
+            this.off(keys[i], '*');
         }
     }
 

--- a/event-pubsub.js
+++ b/event-pubsub.js
@@ -13,7 +13,7 @@ function sub(type,handler){
 }
 
 function unsub(type,handler){
-    if(!handler && type !== '*'){
+    if(!handler){
         var err=new ReferenceError('handler not defined. if you wish to remove all handlers from the event please pass "*" as the handler');
         throw err;
     }
@@ -28,7 +28,7 @@ function unsub(type,handler){
             i<count;
             i++
         ){
-            this.off(keys[i], '*');
+            unsub.call(this, keys[i], handler);
         }
     }
 

--- a/examples/browser/basic.js
+++ b/examples/browser/basic.js
@@ -34,7 +34,7 @@ events.on(
     'world',
     function(data){
         eventLog.log('World event got',data);
-        events.off('*');
+        events.off('*', '*');
         eventLog.log('Removed all events')
     }
 );

--- a/examples/node/basic.js
+++ b/examples/node/basic.js
@@ -34,7 +34,7 @@ events.on(
     'world',
     function(data){
         console.log('World event got',data);
-        events.off('*');
+        events.off('*', '*');
         console.log('Removed all events');
     }
 );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "event-pubsub",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Pubsub events for Node and the browser allowing event scoping and multiple scopes. Easy for any developer level. No frills, just high speed pubsub events!",
   "main": "event-pubsub.js",
   "directories": {


### PR DESCRIPTION
same as @conordickinson , but first remove the '*' event to avoid infinite loop.

In fact, I want to use node-ipc. but when i exec `ipc.disconnect('NAME')`, i got an error.
so... i found this bug.

 :laughing: 
