### PR TITLE
Adds engine hint to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "bugs": {
     "url": "https://github.com/RIAEvangelist/event-pubsub/issues"
   },
-  "homepage": "https://github.com/RIAEvangelist/event-pubsub"
+  "homepage": "https://github.com/RIAEvangelist/event-pubsub",
+  "engines": {
+    "node": ">=5.0.0"
+  }
 }


### PR DESCRIPTION
This module includes native ES2015 code since v3.0.0. In older `node` versions that do not implement the spread operator, the process crashes. This PR sets the `engine` property in the `package.json` to `>=5.0.0` let users know about the compatibility issue during the install and prevent installing newer versions if the users choose to configure the `engine-strict` flag of `npm`.

In addition, the PR should be ported to v3.0.0 too (branch from that version, apply the change, create v3.0.1 and publish).