### PR TITLE
ci: fix Node.js matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,7 +19,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        node_version:
+        node-version:
           - 14.x
           - 16.x
     steps:


### PR DESCRIPTION
Previously, all tests were running against the default LTS version of Node.js at the time of the run. This fixes the mismatched Node.js version matrix variable.

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>